### PR TITLE
AJNZ-7-Implement-move-constructor-example

### DIFF
--- a/ModernCppBasics/ModernCppBasics.vcxproj
+++ b/ModernCppBasics/ModernCppBasics.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\Move-Semantics.cpp" />
     <ClCompile Include="src\RAII.cpp" />
     <ClCompile Include="src\SmartPointers.cpp" />
   </ItemGroup>

--- a/ModernCppBasics/ModernCppBasics.vcxproj.filters
+++ b/ModernCppBasics/ModernCppBasics.vcxproj.filters
@@ -18,5 +18,14 @@
     <ClCompile Include="src\RAII.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\SmartPointers.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Move-Semantics.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\README.md" />
   </ItemGroup>
 </Project>

--- a/ModernCppBasics/src/Move-Semantics.cpp
+++ b/ModernCppBasics/src/Move-Semantics.cpp
@@ -47,6 +47,16 @@ namespace MoveSemantics {
 
 		}
 
+		TestClassMS(TestClassMS&& inp) noexcept {
+			testData = inp.testData;
+			testString = inp.testString;
+			inp.testData = NULL;
+			inp.testString = "";
+
+			std::cout << "Move constructor called. testData = " << testData << ", testString = " << testString << std::endl;
+
+		}
+
 		void printObj() {
 			std::cout << "printObj called. testData = " << testData << ", testString = " << testString << std::endl;
 		}
@@ -62,13 +72,15 @@ int main() {
 	MoveSemantics::TestClassMS myObj2(3);
 	MoveSemantics::TestClassMS myObj3("Test");
 	MoveSemantics::TestClassMS myObj4(3, "Test");
-	MoveSemantics::TestClassMS myObj5(myObj3);
+	MoveSemantics::TestClassMS myObj5(myObj3); // Copy constructor
 
 	std::cout << "start printing!\n";
 
 	myObj1.printObj();
 
-
+	MoveSemantics::TestClassMS myObj6(std::move(myObj2)); // Move constructor
+	myObj2.printObj(); // myObj2 should be in a valid but unspecified state after move
+	myObj6.printObj();
 
 	return 0;
 }

--- a/ModernCppBasics/src/Move-Semantics.cpp
+++ b/ModernCppBasics/src/Move-Semantics.cpp
@@ -1,0 +1,75 @@
+#define RUN_MOVESEMANTICS
+
+#include <iostream>
+#include <string>
+
+
+namespace MoveSemantics {
+
+	class TestClassMS {
+
+	private:
+		int testData;
+		std::string testString;
+
+	public:
+		TestClassMS() {
+			testData = 42;
+			testString = "Hello, World!";
+			std::cout << "Constructor called. testData = " << testData << ", testString = " << testString << std::endl;
+		}
+
+		TestClassMS(int data) {
+			testData = data;
+			testString = "Hello, World!";
+			std::cout << "Parameterized constructor called. testData = " << testData << ", testString = " << testString << std::endl;
+		}
+
+		TestClassMS(std::string data) {
+			testData = 43;
+			testString = data;
+
+			std::cout << "Parameterized constructor called with string. testData = " << testData << ", testString = " << testString << std::endl;
+		}
+
+		TestClassMS(int datai, std::string datas) {
+			testData = datai;
+			testString = datas;
+
+
+			std::cout << "Parameterized constructor called with int and string. testData = " << testData << ", testString = " << testString << std::endl;
+		}
+
+		TestClassMS(TestClassMS& inp) noexcept {
+			testData = inp.testData;
+			testString = inp.testString;
+			std::cout << "Copy constructor called. testData = " << testData << ", testString = " << testString << std::endl;
+
+		}
+
+		void printObj() {
+			std::cout << "printObj called. testData = " << testData << ", testString = " << testString << std::endl;
+		}
+	};
+} // namespace MoveSemantics
+
+
+
+#ifdef RUN_MOVESEMANTICS
+int main() {
+
+	MoveSemantics::TestClassMS myObj1;
+	MoveSemantics::TestClassMS myObj2(3);
+	MoveSemantics::TestClassMS myObj3("Test");
+	MoveSemantics::TestClassMS myObj4(3, "Test");
+	MoveSemantics::TestClassMS myObj5(myObj3);
+
+	std::cout << "start printing!\n";
+
+	myObj1.printObj();
+
+
+
+	return 0;
+}
+#endif // RUN_MOVESEMANTICS

--- a/ModernCppBasics/src/RAII.cpp
+++ b/ModernCppBasics/src/RAII.cpp
@@ -2,20 +2,20 @@
 
 #include <iostream>
 
-
-	class TestClass {
+namespace RAII {
+	class TestClassRAII {
 	private:
 		int testData;
 
 	public:
 		// Constructor
-		TestClass() {
+		TestClassRAII() {
 			testData = 42;
 			std::cout << "Constructor called. testData = " << testData << std::endl;
 		}
 
 		// Destructor
-		~TestClass() {
+		~TestClassRAII() {
 			std::cout << "Destructor called." << std::endl;
 			//delete &testData;
 
@@ -31,31 +31,33 @@
 
 	void doSomething() {
 		// This function is just to demonstrate that the destructor will be called when the object goes out of scope.
-		TestClass localObj;
+		TestClassRAII localObj;
 		std::cout << "Inside doSomething, testData = " << localObj.getTestData() << std::endl;
 	} // localObj goes out of scope here, and its destructor is called.
+} // namespace RAII
+
 
 #ifdef RUN_RAII
-	int main() {
-		// RAII is a programming idom. Shortly it means that resources are acquired during the lifetime of an object 
-		// and released when the object goes out of scope.
-		// RAII is a common pattern in C++ for managing resources such as memory, file handles, and network connections.
+int main() {
+	// RAII is a programming idom. Shortly it means that resources are acquired during the lifetime of an object 
+	// and released when the object goes out of scope.
+	// RAII is a common pattern in C++ for managing resources such as memory, file handles, and network connections.
 
-		TestClass objNew; // Creates an object on the stack
-		TestClass* objNew2 = new TestClass(); // Creates another object on the heap
-		std::cout << "Accessing testData on stack: " << objNew.getTestData() << std::endl;
-		std::cout << "Accessing testData on heap: " << objNew2->getTestData() << std::endl;
+	RAII::TestClassRAII objNew; // Creates an object on the stack
+	RAII::TestClassRAII* objNew2 = new RAII::TestClassRAII(); // Creates another object on the heap
+	std::cout << "Accessing testData on stack: " << objNew.getTestData() << std::endl;
+	std::cout << "Accessing testData on heap: " << objNew2->getTestData() << std::endl;
 
-		doSomething(); // Call a function that creates a local object, demonstrating RAII
+	RAII::doSomething(); // Call a function that creates a local object, demonstrating RAII
 
-		// When the function doSomething() returns, the local object localObj is destroyed, and its destructor is called.
-		// When the main function returns, the stack object objNew is destroyed, and its destructor is called.
+	// When the function doSomething() returns, the local object localObj is destroyed, and its destructor is called.
+	// When the main function returns, the stack object objNew is destroyed, and its destructor is called.
 
-		// even we don't call the destructors of the classes, when we start the program we can see both creation and destruction of object on te stack.
+	// even we don't call the destructors of the classes, when we start the program we can see both creation and destruction of object on te stack.
 
-		delete objNew2;  // you can uncomment this line to manually delete the heap object and see the difference
+	delete objNew2;  // you can uncomment this line to manually delete the heap object and see the difference
 
 
-		return 0;
-	}// Note: The destructor for objNew2 will be called automatically when the program exits, but it's a good practice to delete heap-allocated objects to avoid memory leaks.
+	return 0;
+}// Note: The destructor for objNew2 will be called automatically when the program exits, but it's a good practice to delete heap-allocated objects to avoid memory leaks.
 #endif

--- a/ModernCppBasics/src/SmartPointers.cpp
+++ b/ModernCppBasics/src/SmartPointers.cpp
@@ -1,9 +1,9 @@
-#define RUN_SMAARTPTR
+//#define RUN_SMAARTPTR
 
 #include <iostream>
 #include <memory>
 
-
+namespace SmartPointers {
 	class vec2 {
 	private:
 		double x;
@@ -78,25 +78,25 @@
 
 		}
 	};
-
+} // namespace SmartPointers
 
 #ifdef RUN_SMAARTPTR
-	int main() {
+int main() {
 
-		std::unique_ptr<triangle> ptr1(new triangle(vec2(-1, 0), vec2(0, 1), vec2(1, 0)));
+	std::unique_ptr<SmartPointers::triangle> ptr1(new SmartPointers::triangle(SmartPointers::vec2(-1, 0), SmartPointers::vec2(0, 1), SmartPointers::vec2(1, 0)));
 
-		std::shared_ptr<triangle> ptr2(new triangle(vec2(-1, 2), vec2(2, 1), vec2(1, 2)));
+	std::shared_ptr<SmartPointers::triangle> ptr2(new SmartPointers::triangle(SmartPointers::vec2(-1, 2), SmartPointers::vec2(2, 1), SmartPointers::vec2(1, 2)));
 
-		std::shared_ptr<triangle> ptr3 = ptr2; // shared ownership
+	std::shared_ptr<SmartPointers::triangle> ptr3 = ptr2; // shared ownership
 
-		std::cout << "Drawing triangles:" << std::endl;
-		std::cout << "ptr1\n";
-		ptr1.get()->draw();
-		std::cout << "ptr2\n";
-		ptr2.get()->draw();
-		std::cout << "ptr3\n";
-		ptr3.get()->draw();
-		
-		return 0;
-	}
+	std::cout << "Drawing triangles:" << std::endl;
+	std::cout << "ptr1\n";
+	ptr1.get()->draw();
+	std::cout << "ptr2\n";
+	ptr2.get()->draw();
+	std::cout << "ptr3\n";
+	ptr3.get()->draw();
+
+	return 0;
+}
 #endif


### PR DESCRIPTION
Implemented Copy/Move constructer examples
Created namespaces to prevent unwanted overloading of class/methods